### PR TITLE
Manually install VS MSMs on GitHub Actions again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,26 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      # TODO: Remove this step when https://github.com/actions/virtual-environments/issues/5143 is fixed
+      - name: install Microsoft.VisualStudio.Component.VC.Redist.MSM
+        run: |
+          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          $componentsToAdd = @(
+            "Microsoft.VisualStudio.Component.VC.Redist.MSM"
+          )
+          [string]$workloadArgs = $componentsToAdd | ForEach-Object {" --add " +  $_}
+          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+          if ($process.ExitCode -eq 0)
+          {
+              Write-Host "components have been successfully added"
+          }
+          else
+          {
+              Write-Host "components were not installed"
+              exit 1
+          }
       - name: rustup
         uses: actions-rs/toolchain@v1
         with:
@@ -43,6 +63,26 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      # TODO: Remove this step when https://github.com/actions/virtual-environments/issues/5143 is fixed
+      - name: install Microsoft.VisualStudio.Component.VC.Redist.MSM
+        run: |
+          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          $componentsToAdd = @(
+            "Microsoft.VisualStudio.Component.VC.Redist.MSM"
+          )
+          [string]$workloadArgs = $componentsToAdd | ForEach-Object {" --add " +  $_}
+          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+          if ($process.ExitCode -eq 0)
+          {
+              Write-Host "components have been successfully added"
+          }
+          else
+          {
+              Write-Host "components were not installed"
+              exit 1
+          }
       - name: rustup
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
It looks like they're missing again since actions/virtual-environments#5143 was fixed